### PR TITLE
add more file suffix for Cpp files

### DIFF
--- a/Gitt/SyntaxHelper.m
+++ b/Gitt/SyntaxHelper.m
@@ -34,7 +34,7 @@ static NSArray *mapping;
                    @"Bash,bash,sh",
                    @"CSharp,cs",
                    @"ColdFusion",
-                   @"Cpp,m,h,cpp,c",
+                   @"Cpp,m,h,cpp,c,hpp,cc",
                    @"Css,css",
                    @"Delphi,pas",
                    @"Diff,diff",


### PR DESCRIPTION
hpp for C++ template implementation file.
cc for c++ cpp file.

both are frequently used.
